### PR TITLE
Set start  & stop times so durtion can be properly calculated

### DIFF
--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -106,8 +106,7 @@ func secondsToMillis(seconds float64) int64 {
 }
 
 func parseTimeString(timeString string) (int64, error) {	
-	layout := time.RFC3339Nano
-	t, err := time.Parse(layout, timeString)
+	t, err := time.Parse(time.RFC3339Nano, timeString)
 	if err != nil {
 		return 0, err
 	}

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/ctrf-io/go-ctrf-json-reporter/ctrf"
 )
@@ -33,7 +34,7 @@ func ParseTestResults(r io.Reader, verbose bool, env *ctrf.Environment) (*ctrf.R
 	}
 
 	report := ctrf.NewReport("gotest", env)
-
+	report.Results.Summary.Start = time.Now().UnixNano() / int64(time.Millisecond)
 	for _, event := range testEvents {
 		if verbose {
 			jsonEvent, err := json.Marshal(event)
@@ -42,35 +43,49 @@ func ParseTestResults(r io.Reader, verbose bool, env *ctrf.Environment) (*ctrf.R
 			}
 			fmt.Println(string(jsonEvent))
 		}
-		if event.Test != "" {
-			if event.Action == "pass" {
-				report.Results.Summary.Tests++
-				report.Results.Summary.Passed++
-				report.Results.Tests = append(report.Results.Tests, &ctrf.TestResult{
-					Name:     event.Test,
-					Status:   ctrf.TestPassed,
-					Duration: secondsToMillis(event.Elapsed),
-				})
-			} else if event.Action == "fail" {
-				report.Results.Summary.Tests++
-				report.Results.Summary.Failed++
-				report.Results.Tests = append(report.Results.Tests, &ctrf.TestResult{
-					Name:     event.Test,
-					Status:   ctrf.TestFailed,
-					Duration: secondsToMillis(event.Elapsed),
-				})
-			} else if event.Action == "skip" {
-				report.Results.Summary.Tests++
-				report.Results.Summary.Skipped++
-				report.Results.Tests = append(report.Results.Tests, &ctrf.TestResult{
-					Name:     event.Test,
-					Status:   ctrf.TestSkipped,
-					Duration: secondsToMillis(event.Elapsed),
-				})
+		if event.Test == "" {
+			continue
+		}
+		startTime, err := parseTimeString(event.Time)
+		duration := secondsToMillis(event.Elapsed)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error parsing test event start time '%s' : %v\n", event.Time, err)
+		} else {
+			if report.Results.Summary.Start > startTime {
+				report.Results.Summary.Start = startTime
+			}
+			endTime := startTime + duration
+			if report.Results.Summary.Stop < endTime {
+				report.Results.Summary.Stop = endTime
 			}
 		}
-	}
 
+		if event.Action == "pass" {
+			report.Results.Summary.Tests++
+			report.Results.Summary.Passed++
+			report.Results.Tests = append(report.Results.Tests, &ctrf.TestResult{
+				Name:     event.Test,
+				Status:   ctrf.TestPassed,
+				Duration: duration,
+			})
+		} else if event.Action == "fail" {
+			report.Results.Summary.Tests++
+			report.Results.Summary.Failed++
+			report.Results.Tests = append(report.Results.Tests, &ctrf.TestResult{
+				Name:     event.Test,
+				Status:   ctrf.TestFailed,
+				Duration: duration,
+			})
+		} else if event.Action == "skip" {
+			report.Results.Summary.Tests++
+			report.Results.Summary.Skipped++
+			report.Results.Tests = append(report.Results.Tests, &ctrf.TestResult{
+				Name:     event.Test,
+				Status:   ctrf.TestSkipped,
+				Duration: duration,
+			})
+		}
+	}
 	return report, nil
 }
 
@@ -86,4 +101,18 @@ func WriteReportToFile(filename string, report *ctrf.Report) error {
 
 func secondsToMillis(seconds float64) int64 {
 	return int64(seconds * 1000)
+}
+func parseTimeString(timeString string) (int64, error) {
+	// Define the layout for parsing the time string
+	layout := time.RFC3339Nano
+
+	// Parse the time string
+	t, err := time.Parse(layout, timeString)
+	if err != nil {
+		return 0, err
+	}
+
+	// Convert the time to Unix timestamp in milliseconds
+	timestamp := t.UnixNano() / int64(time.Millisecond)
+	return timestamp, nil
 }


### PR DESCRIPTION
noticed (using https://github.com/ctrf-io/github-actions-test-reporter-ctrf) that the duration is always zero.. dug into it and noticed the relevant properties in the summary are not set.
so I think this will fix it.

fixes: https://github.com/ctrf-io/go-ctrf-json-reporter/issues/2
