### PR TITLE
Set .suite property to the go package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The test object in the report includes the following [CTRF properties](https://c
 
 | Name       | Type   | Required | Details                                                                             |
 | ---------- | ------ | -------- | ----------------------------------------------------------------------------------- |
+| `suite`    | String | Required | The name of go package containing the test.                                         |
 | `name`     | String | Required | The name of the test.                                                               |
 | `status`   | String | Required | The outcome of the test. One of: `passed`, `failed`, `skipped`, `pending`, `other`. |
 | `duration` | Number | Required | The time taken for the test execution, in milliseconds.                             |

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -47,6 +47,7 @@ func ParseTestResults(r io.Reader, verbose bool, env *ctrf.Environment) (*ctrf.R
 				report.Results.Summary.Tests++
 				report.Results.Summary.Passed++
 				report.Results.Tests = append(report.Results.Tests, &ctrf.TestResult{
+					Suite:    event.Package,
 					Name:     event.Test,
 					Status:   ctrf.TestPassed,
 					Duration: secondsToMillis(event.Elapsed),
@@ -55,6 +56,7 @@ func ParseTestResults(r io.Reader, verbose bool, env *ctrf.Environment) (*ctrf.R
 				report.Results.Summary.Tests++
 				report.Results.Summary.Failed++
 				report.Results.Tests = append(report.Results.Tests, &ctrf.TestResult{
+					Suite:    event.Package,
 					Name:     event.Test,
 					Status:   ctrf.TestFailed,
 					Duration: secondsToMillis(event.Elapsed),
@@ -63,6 +65,7 @@ func ParseTestResults(r io.Reader, verbose bool, env *ctrf.Environment) (*ctrf.R
 				report.Results.Summary.Tests++
 				report.Results.Summary.Skipped++
 				report.Results.Tests = append(report.Results.Tests, &ctrf.TestResult{
+					Suite:    event.Package,
 					Name:     event.Test,
 					Status:   ctrf.TestSkipped,
 					Duration: secondsToMillis(event.Elapsed),


### PR DESCRIPTION
fixes https://github.com/ctrf-io/go-ctrf-json-reporter/issues/4