### PR TITLE
Adds extra fields per #17

### DIFF
--- a/ctrf/ctrf.go
+++ b/ctrf/ctrf.go
@@ -7,19 +7,39 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 type Report struct {
-	Results *Results `json:"results"`
+	ReportFormat string      `json:"reportFormat"`
+	SpecVersion  string      `json:"specVersion"`
+	ReportId     string      `json:"reportId,omitempty"`
+	Timestamp    time.Time   `json:"timestamp,omitempty"`
+	GeneratedBy  string      `json:"generatedBy,omitempty"`
+	Results      *Results    `json:"results"`
+	Extra        interface{} `json:"extra,omitempty"`
 }
+
+const (
+	ReportFormatCTRF   = "CTRF"
+	SpecVersionCTRF    = "0.0.0"
+	GeneratedByDefault = "go-ctrf-json-reporter"
+)
 
 func NewReport(toolName string, env *Environment) *Report {
 	return &Report{
+		ReportFormat: ReportFormatCTRF,
+		SpecVersion:  SpecVersionCTRF,
+		ReportId:     uuid.New().String(),
+		Timestamp:    time.Now(),
 		Results: &Results{
 			Tool:        &Tool{Name: toolName},
 			Environment: env,
 			Summary:     &Summary{},
 		},
+		GeneratedBy: GeneratedByDefault,
 	}
 }
 

--- a/ctrf/ctrf_test.go
+++ b/ctrf/ctrf_test.go
@@ -2,9 +2,10 @@ package ctrf
 
 import (
 	"encoding/json"
-	"gopkg.in/yaml.v3"
 	"os"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -12,6 +13,8 @@ import (
 func TestRequiredProperties(t *testing.T) {
 	// Arrange
 	report := Report{
+		ReportFormat: ReportFormatCTRF,
+		SpecVersion:  SpecVersionCTRF,
 		Results: &Results{
 			Tool: &Tool{
 				Name: "my tool",
@@ -57,6 +60,9 @@ func TestRequiredProperties(t *testing.T) {
 	}
 
 	expectedJson := `{
+  "reportFormat": "CTRF",
+  "specVersion": "0.0.0",
+  "timestamp": "0001-01-01T00:00:00Z",
   "results": {
     "tool": {
       "name": "my tool"

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,12 @@ module github.com/ctrf-io/go-ctrf-json-reporter
 go 1.19
 
 require (
+	github.com/google/uuid v1.6.0
+	github.com/stretchr/testify v1.9.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,12 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR implements the changes proposed in #17.

Based off my reading of the spec, it seems that it just needs the fields added as part of `NewReport`, but if that's not the case please let me know.

The timestamp is stored internally as a `time.Time`. For unmarshaling and marshaling, this will use [RFC3339](https://pkg.go.dev/time#Time.MarshalJSON), which is approximately equivalent to ISO8601 (although with some [notable differences](https://ijmacd.github.io/rfc3339-iso8601/)).

Thanks!
