### PR TITLE
fix: incorrect filePath capitalization

### DIFF
--- a/ctrf/ctrf.go
+++ b/ctrf/ctrf.go
@@ -215,7 +215,7 @@ type TestResult struct {
 	RawStatus  string     `json:"rawStatus,omitempty"`
 	Tags       []string   `json:"tags,omitempty"`
 	Type       string     `json:"type,omitempty"`
-	Filepath   string     `json:"filepath,omitempty"`
+	Filepath   string     `json:"filePath,omitempty"`
 	Retry      int        `json:"retry,omitempty"`
 	Flake      bool       `json:"flake,omitempty"`
 	Browser    string     `json:"browser,omitempty"`


### PR DESCRIPTION
According to [the spec](https://ctrf.io/docs/specification/test), the correct key for the path of the test file is `filePath`, not `filepath`. This causes ctrf/github-test-reporter not to be able to group Golang tests by suites or files.