### PR TITLE
fix: suite field should be an array per CTRF schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,13 @@ func runTests(destinationReportFile string) error {
 
 The test object in the report includes the following [CTRF properties](https://ctrf.io/docs/schema/test):
 
-| Name       | Type   | Required | Details                                                                             |
-| ---------- | ------ | -------- | ----------------------------------------------------------------------------------- |
-| `name`     | String | Required | The name of the test.                                                               |
-| `status`   | String | Required | The outcome of the test. One of: `passed`, `failed`, `skipped`, `pending`, `other`. |
-| `duration` | Number | Required | The time taken for the test execution, in milliseconds.                             |
-| `message`  | String | Optional | The failure message if the test failed.                                             |
-| `suite`    | String | Required | The name of go package containing the test.                                         |
+| Name       | Type            | Required | Details                                                                             |
+| ---------- | --------------- | -------- | ------------------------------------------------------------------------------------ |
+| `name`     | String          | Required | The name of the test.                                                               |
+| `status`   | String          | Required | The outcome of the test. One of: `passed`, `failed`, `skipped`, `pending`, `other`. |
+| `duration` | Number          | Required | The time taken for the test execution, in milliseconds.                             |
+| `message`  | String          | Optional | The failure message if the test failed.                                             |
+| `suite`    | Array of String | Required | The go package containing the test, as a single-element suite hierarchy.            |
 
 ## Troubleshoot
 

--- a/ctrf/ctrf.go
+++ b/ctrf/ctrf.go
@@ -227,7 +227,7 @@ type TestResult struct {
 	Duration      int64          `json:"duration"`
 	Start         int64          `json:"start,omitempty"`
 	Stop          int64          `json:"stop,omitempty"`
-	Suite         string         `json:"suite,omitempty"`
+	Suite         []string       `json:"suite,omitempty"`
 	Message       string         `json:"message,omitempty"`
 	Trace         string         `json:"trace,omitempty"`
 	RawStatus     string         `json:"rawStatus,omitempty"`

--- a/ctrf/ctrf_test.go
+++ b/ctrf/ctrf_test.go
@@ -120,6 +120,32 @@ func TestRequiredProperties(t *testing.T) {
 	assert.JSONEq(t, expectedJson, actualJson)
 }
 
+func TestSuiteIsSerializedAsArray(t *testing.T) {
+	// Arrange
+	// The CTRF schema defines 'suite' as an array of strings representing the
+	// suite hierarchy from top-level to immediate parent, not a single string.
+	// https://github.com/ctrf-io/ctrf/blob/5fa00f7ab68eebb9fb1b9a1ffa4cf004827c653d/schema/ctrf.schema.json#L160-L167
+	testResult := TestResult{
+		Name:     "test 1",
+		Status:   TestPassed,
+		Duration: 10,
+		Suite:    []string{"parent suite", "child suite"},
+	}
+
+	// Act
+	data, err := json.Marshal(testResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, []any{"parent suite", "child suite"}, decoded["suite"])
+}
+
 func TestValidation(t *testing.T) {
 	forEachValidationTestCase(t, allTestCase, func(t *testing.T, testCase validationTestCase, report *Report) {
 		t.Helper()

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -137,7 +137,7 @@ func ParseTestResults(r io.Reader, verbose bool, env *ctrf.Environment) (*ctrf.R
 
 			// Build the TestResult for this test event, and add it to the report.
 			newResult := &ctrf.TestResult{
-				Suite:    event.Package,
+				Suite:    []string{event.Package},
 				Name:     event.Test,
 				Status:   actionToTestResult(event.Action),
 				Duration: secondsToMillis(event.Elapsed),
@@ -256,7 +256,7 @@ func actionToTestResult(action string) ctrf.TestStatus {
 // findTest searches through the already-parsed test results to find a matching test.
 func findTest(suite string, name string, tests []*ctrf.TestResult) *ctrf.TestResult {
 	for _, test := range tests {
-		if test.Suite == suite && test.Name == name {
+		if len(test.Suite) == 1 && test.Suite[0] == suite && test.Name == name {
 			return test
 		}
 	}

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -149,7 +150,7 @@ func ParseTestResults(r io.Reader, verbose bool, env *ctrf.Environment) (*ctrf.R
 			// Search through the existing results for a prior run. If this is a duplicate of an existing failure,
 			// then this is likely a retry of a potentially flaky test, so update the existing test result instead
 			// of creating a new one.
-			if existingResult := findTest(event.Package, event.Test, report.Results.Tests); existingResult == nil {
+			if existingResult := findTest(newResult.Suite, newResult.Name, report.Results.Tests); existingResult == nil {
 				addResult(report, newResult)
 			} else {
 				updateResult(report, existingResult, newResult)
@@ -254,9 +255,9 @@ func actionToTestResult(action string) ctrf.TestStatus {
 }
 
 // findTest searches through the already-parsed test results to find a matching test.
-func findTest(suite string, name string, tests []*ctrf.TestResult) *ctrf.TestResult {
+func findTest(suite []string, name string, tests []*ctrf.TestResult) *ctrf.TestResult {
 	for _, test := range tests {
-		if len(test.Suite) == 1 && test.Suite[0] == suite && test.Name == name {
+		if slices.Equal(suite, test.Suite) && test.Name == name {
 			return test
 		}
 	}

--- a/reporter/reporter_test.go
+++ b/reporter/reporter_test.go
@@ -15,7 +15,7 @@ func Test_Enrich_Reporter(t *testing.T) {
 		{
 			Name:     "Test_Enrich_Reporter",
 			Status:   "passed",
-			Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/reporter",
+			Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/reporter"},
 			Filepath: "reporter_test.go",
 			Start:    1740874081832,
 			Stop:     1740874081832,
@@ -43,7 +43,7 @@ func Test_Enrich_ReporterWithUnorderedMessages(t *testing.T) {
 		{
 			Name:     "Test_Enrich_Reporter/Test1",
 			Status:   "passed",
-			Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/reporter",
+			Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/reporter"},
 			Filepath: "reporter_test.go",
 			Start:    1760718477126,
 			Stop:     1760718477126,
@@ -51,7 +51,7 @@ func Test_Enrich_ReporterWithUnorderedMessages(t *testing.T) {
 		{
 			Name:     "Test_Enrich_Reporter/Test2",
 			Status:   "passed",
-			Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/reporter",
+			Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/reporter"},
 			Filepath: "reporter_test.go",
 			Start:    1760718477126,
 			Stop:     1760718477126,
@@ -59,7 +59,7 @@ func Test_Enrich_ReporterWithUnorderedMessages(t *testing.T) {
 		{
 			Name:     "Test_Enrich_Reporter/Test3",
 			Status:   "passed",
-			Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/reporter",
+			Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/reporter"},
 			Filepath: "reporter_test.go",
 			Start:    1760718477126,
 			Stop:     1760718477126,
@@ -67,7 +67,7 @@ func Test_Enrich_ReporterWithUnorderedMessages(t *testing.T) {
 		{
 			Name:     "Test_Enrich_Reporter/Test4",
 			Status:   "passed",
-			Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/reporter",
+			Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/reporter"},
 			Filepath: "reporter_test.go",
 			Start:    1760718477126,
 			Stop:     1760718477126,
@@ -75,7 +75,7 @@ func Test_Enrich_ReporterWithUnorderedMessages(t *testing.T) {
 		{
 			Name:     "Test_Enrich_Reporter/Test5",
 			Status:   "failed",
-			Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/reporter",
+			Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/reporter"},
 			Filepath: "reporter_test.go",
 			Message:  "=== RUN   Test_Enrich_Reporter/Test5\n    reporter:59: Something.Skip() = false, want true\n    --- FAIL: Test_Enrich_Reporter/Test5 (0.00s)\n",
 			Start:    1760718477126,
@@ -84,7 +84,7 @@ func Test_Enrich_ReporterWithUnorderedMessages(t *testing.T) {
 		{
 			Name:     "Test_Enrich_Reporter/Test6",
 			Status:   "passed",
-			Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/reporter",
+			Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/reporter"},
 			Filepath: "reporter_test.go",
 			Start:    1760718477126,
 			Stop:     1760718477126,
@@ -92,7 +92,7 @@ func Test_Enrich_ReporterWithUnorderedMessages(t *testing.T) {
 		{
 			Name:     "Test_Enrich_Reporter/Test7",
 			Status:   "passed",
-			Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/reporter",
+			Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/reporter"},
 			Filepath: "reporter_test.go",
 			Start:    1760718477126,
 			Stop:     1760718477126,
@@ -100,7 +100,7 @@ func Test_Enrich_ReporterWithUnorderedMessages(t *testing.T) {
 		{
 			Name:     "Test_Enrich_Reporter",
 			Status:   "failed",
-			Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/reporter",
+			Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/reporter"},
 			Filepath: "reporter_test.go",
 			Message:  "=== RUN   Test_Enrich_Reporter\n--- FAIL: Test_Enrich_Reporter (0.00s)\n",
 			Start:    1760718477126,
@@ -167,7 +167,7 @@ func TestDetectFlakyTests(t *testing.T) {
 			{
 				Name:     "Test_Flaky_Pass",
 				Status:   ctrf.TestPassed,
-				Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/examples/flaky",
+				Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/examples/flaky"},
 				Filepath: "reporter_test.go", // Filepath enrichment is based on grepping the current path, so this file is the one that gets found
 				Start:    1775245677812,
 				Stop:     1775245677863,
@@ -176,7 +176,7 @@ func TestDetectFlakyTests(t *testing.T) {
 			{
 				Name:     "Test_Flaky_Fail",
 				Status:   ctrf.TestFailed,
-				Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/examples/flaky",
+				Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/examples/flaky"},
 				Filepath: "reporter_test.go",
 				Retries:  3,
 				Start:    1775245677863, // The start time of the first event for the first retry
@@ -201,7 +201,7 @@ func TestDetectFlakyTests(t *testing.T) {
 			{
 				Name:     "Test_Flaky_Skipped",
 				Status:   ctrf.TestSkipped,
-				Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/examples/flaky",
+				Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/examples/flaky"},
 				Filepath: "reporter_test.go",
 				Start:    1775245677914,
 				Stop:     1775245677914,
@@ -209,7 +209,7 @@ func TestDetectFlakyTests(t *testing.T) {
 			{
 				Name:     "Test_Flaky_Flaky",
 				Status:   ctrf.TestPassed,
-				Suite:    "github.com/ctrf-io/go-ctrf-json-reporter/examples/flaky",
+				Suite:    []string{"github.com/ctrf-io/go-ctrf-json-reporter/examples/flaky"},
 				Filepath: "reporter_test.go",
 				Retries:  3,
 				Flaky:    true,


### PR DESCRIPTION
## Summary
- The CTRF schema defines `results.tests[].suite` as an array of strings (the suite hierarchy from top-level to immediate parent), but this reporter emitted a plain string, causing schema drift.
- Changed `ctrf.TestResult.Suite` from `string` to `[]string`, and the reporter now reports the go package as a single-element suite array (`[]string{event.Package}`).
- Updated `README.md`'s test object property table accordingly.

Fixes #29

## Test plan
- [x] Added `TestSuiteIsSerializedAsArray` (TDD, red → green) asserting `suite` marshals as a JSON array
- [x] Updated existing reporter tests' expectations for the new `[]string` type
- [x] `go build ./...`
- [x] `go test ./...`